### PR TITLE
Fix: ensure plugin initializer directory exists before file creation

### DIFF
--- a/src/GeniePlugins.jl
+++ b/src/GeniePlugins.jl
@@ -6,7 +6,6 @@ module GeniePlugins
 import Genie
 import Pkg, Markdown, Logging
 
-
 const FILES_FOLDER = "files"
 const PLUGINS_FOLDER = Genie.config.path_plugins
 const TASKS_FOLDER = Genie.config.path_tasks
@@ -101,7 +100,11 @@ function scaffold(plugin_name::String, dest::String = "."; force = false)
     recursive_copy(path, joinpath(dest, FILES_FOLDER), force = force)
   end
 
-  initializer_path = joinpath(dest, FILES_FOLDER, PLUGINS_FOLDER, lowercase(plugin_name) * ".jl")
+  #this is the fix
+  initializer_dir = joinpath(dest, FILES_FOLDER, PLUGINS_FOLDER)
+  mkpath(initializer_dir)  # Ensure the directory exists
+  initializer_path = joinpath(initializer_dir, lowercase(plugin_name) * ".jl")
+  # end of fix
   @info "Creating plugin initializer at $initializer_path"
   touch(initializer_path)
 

--- a/src/GeniePlugins.jl
+++ b/src/GeniePlugins.jl
@@ -100,11 +100,10 @@ function scaffold(plugin_name::String, dest::String = "."; force = false)
     recursive_copy(path, joinpath(dest, FILES_FOLDER), force = force)
   end
 
-  #this is the fix
   initializer_dir = joinpath(dest, FILES_FOLDER, PLUGINS_FOLDER)
   mkpath(initializer_dir)  # Ensure the directory exists
   initializer_path = joinpath(initializer_dir, lowercase(plugin_name) * ".jl")
-  # end of fix
+
   @info "Creating plugin initializer at $initializer_path"
   touch(initializer_path)
 


### PR DESCRIPTION
This patch ensures that the plugins directory is created before calling `touch` on the plugin initializer file.